### PR TITLE
Specify which resource fields are mandatory when using the resource_fields approach

### DIFF
--- a/example.py
+++ b/example.py
@@ -157,6 +157,9 @@ class TodoItemWithResourceFields:
       'a_list_of_nested_types': fields.List(fields.Nested(ModelWithResourceFields.resource_fields)),
   }
 
+  # Specify which of the resource fields are required
+  required = ['a_string']
+
 class MarshalWithExample(Resource):
   @swagger.operation(
       notes='get something',

--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -189,6 +189,10 @@ def add_model(model_class):
     # resource_fields.
     # If that attribute exists then we deduce the swagger model by the content
     # of this attribute
+
+    if hasattr(model_class, 'required'):
+      required = model['required'] = model_class.required
+
     properties = model['properties'] = {}
     nested = model_class.nested() if isinstance(model_class, _Nested) else {}
     for field_name, field_type in list(model_class.resource_fields.items()):


### PR DESCRIPTION
I noticed that when resource_fields is used (instead of deducing fields from **init**) then there's no way to specify which is required. This patch seems to work well.
