### PR TITLE
extract_operations() looks through MRO

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -94,8 +94,13 @@ class SwaggerEndpoint(object):
   @staticmethod
   def extract_operations(resource, path_arguments=[]):
     operations = []
-    for method in resource.methods:
-      method_impl = resource.__dict__[method.lower()]
+    for method in [m.lower() for m in resource.methods]:
+      method_impl = resource.__dict__.get(method, None)
+      if method_impl is None:
+        for cls in resource.__mro__:
+          for item_key in cls.__dict__.keys():
+            if item_key == method:
+              method_impl = cls.__dict__[item_key]
       op = {
           'method': method,
           'parameters': path_arguments,


### PR DESCRIPTION
extract_operations() looks through MRO to find inherited methods.
Related to https://github.com/rantav/flask-restful-swagger/issues/24
