### PR TITLE
Make use of flask-restful's ReqParser

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -305,6 +305,15 @@ class SwaggerEndpoint(object):
               op[att_name] = att_value
           elif isinstance(att_value, object):
             op[att_name] = att_value.__name__
+        if 'parser' in method_impl.__dict__:
+          arglist = method_impl.__dict__['parser'].__dict__['args']
+          temp_op = []
+          for argobj in arglist:
+            arg = argobj.__dict__
+            #push parameters from reqparse onto our swagger parameters list
+            new_param = {'name': arg['name'], 'required': arg['required'], 'description': arg['help'], 'dataType': arg['type'].__name__}
+            temp_op.append(new_param)
+          op['parameters'] = merge_parameter_list(op['parameters'], temp_op)
       operations.append(op)
     return operations
 

--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -325,7 +325,7 @@ def merge_parameter_list(base, override):
     if o['name'] in names:
       for n, i in enumerate(base):
         if i['name'] == o['name']:
-          base[n] = o
+          base[n] = dict(base[n].items() + o.items())
     else:
       base.append(o)
   return base


### PR DESCRIPTION
Per issue #18, added code to look for a "parser" attribute on a method decorated by @swagger.operation.  If parser is found, then it assumes it to be a ReqParser object and extracts overlapping data between ReqParser and Swagger: name, required, description/help and dataType/type.

This requires ReqParser to be defined and added to method as an attribute per this issue comment:
https://github.com/rantav/flask-restful-swagger/issues/18#issuecomment-52113384
