### PR TITLE
open file in bytes mode fixes UnicodeDecodeError

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -213,7 +213,7 @@ class StaticFiles(Resource):
       mime = 'text/css'
     filePath = os.path.join(rootPath, 'static', filePath)
     if os.path.exists(filePath):
-      fs = open(filePath, "r")
+      fs = open(filePath, "rb")
       return Response(fs, mimetype=mime)
     abort(404)
 


### PR DESCRIPTION
fixes #38
was getting the error too. python 3.4.1
making this change fixes the error and images display properly on the html view 
