### PR TITLE
fix add_model not adding required args when all args are required

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -411,7 +411,8 @@ def add_model(model_class):
       defaults = list(
         zip(argspec.args[-len(argspec.defaults):], argspec.defaults))
     properties = model['properties'] = {}
-    for arg in argspec.args[:-len(defaults)]:
+    required_args_count = len(argspec.args) - len(defaults)
+    for arg in argspec.args[:required_args_count]:
       required.append(arg)
       # type: string for lack of better knowledge, until we add more metadata
       properties[arg] = {'type': 'string'}


### PR DESCRIPTION
When using the **init** method args on a swagger.model to declare fields, if all args were required, then no fields would be added. They would only be added if an optional arg with a default was present. 
example:

```
@swagger.model
class AllRequiredArgs:
    """ No args get added """
    def __init__(self, arg1, arg2, arg3):
        pass

@swagger.model
class SomeOptionalArgs:
    """ All args get added """
    def __init__(self, arg1, arg2, arg3=False):
        pass
```
