### PR TITLE
don't change nicknames in extract_operations()

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -300,7 +300,7 @@ class SwaggerEndpoint(object):
               op['parameters'] = merge_parameter_list(
                 op['parameters'], att_value)
             else:
-              if att_name in op:
+              if att_name in op and att_name is not 'nickname':
                 att_value = '{0}<br/>{1}'.format(att_value, op[att_name])
               op[att_name] = att_value
           elif isinstance(att_value, object):


### PR DESCRIPTION
extract_operations was changing the nickname. e.g. nickname: "addUser" would be changed to "addUser_br_nickname". I found this to be a nuisance when hyperlinking endpoints in Implementation Notes. 
If there's a reason for this, I apologise for not seeing it.
Hope you find this change appropriate.
