### PR TITLE
Allow type definition override on resource_fields. 

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -174,6 +174,7 @@ class TodoItemWithResourceFields:
   resource_fields = {
       'a_string': fields.String(attribute='a_string_field_name'),
       'a_formatted_string': fields.FormattedString,
+      'an_enum': (fields.String, {'enum': ['one', 'two', 'three']}),
       'an_int': fields.Integer,
       'a_bool': fields.Boolean,
       'a_url': fields.Url,


### PR DESCRIPTION
Helps with supplying more complete spec, e.g. enums. If a resource_fields dict value is a tuple, then second element is considered type definition override. The dict's values will be applied on top of whatever is deduced.  
