### PR TITLE
Python3 fix for merging dicts

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -425,7 +425,9 @@ def add_model(model_class):
   if 'swagger_metadata' in dir(model_class):
     for field_name, field_metadata in model_class.swagger_metadata.items():
         if field_name in properties:
-            properties[field_name] = dict(properties[field_name].items() + field_metadata.items())
+            # does not work for Python 3.x; see: http://stackoverflow.com/questions/38987/how-can-i-merge-two-python-dictionaries-in-a-single-expression
+            # properties[field_name] = dict(properties[field_name].items() + field_metadata.items())
+            properties[field_name].update(field_metadata)
 
 def deduce_swagger_type(python_type_or_object, nested_type=None):
     import inspect


### PR DESCRIPTION
`Python3` does not support the `+` operator for 2 dicts to merge them, e.g., in this case:
```
d1 = dict(d1.items() + d2.items())
```

But you can use the `update()` function of `dict` instead:
```
d1.update(d2)
```
This is also shorter and more explicit about the operation to be performed.

See also: http://stackoverflow.com/questions/38987/how-can-i-merge-two-python-dictionaries-in-a-single-expression

Disclaimer: I am unsure if that also works for `Python2` since I never used that yet...