### PR TITLE
Use X-Forwarded-Proto as scheme for fetching internal resources

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -150,7 +150,8 @@ def _get_current_registry(api=None):
   else:
     app_name = request.blueprint
     urlparts =  urlparse.urlparse(request.url_root.rstrip('/'))
-    overrides = {'basePath': urlparse.urlunparse([''] + urlparts[1:])}
+    proto = request.headers.get("x-forwarded-proto") or urlparts[0] 
+    overrides = {'basePath': urlparse.urlunparse([proto] + list(urlparts[1:]))}
 
   if not app_name:
     app_name = 'app'

--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -2,6 +2,7 @@ import functools
 import inspect
 import os
 import re
+import urlparse
 
 from flask import request, abort, Response
 from flask.ext.restful import Resource, fields
@@ -148,7 +149,8 @@ def _get_current_registry(api=None):
     app_name = api.blueprint.name if api.blueprint else None
   else:
     app_name = request.blueprint
-    overrides = {'basePath': request.url_root.rstrip('/')}
+    urlparts =  urlparse.urlparse(request.url_root.rstrip('/'))
+    overrides = {'basePath': urlparse.urlunparse([''] + urlparts[1:])}
 
   if not app_name:
     app_name = 'app'


### PR DESCRIPTION
Heroku, and any other reverse-proxying SSL terminator, makes it difficult to use Swagger effectively if it is desired to have the API endpoints accessible via SSL.  

Requests to an `https` endpoint are proxied via `http` to the application.  When `swagger.py` is constructing paths to access resources for the Swagger UI, it looks at request.url_root and sees an `http` URL, so the URLs in the returned HTML are `http`.  

The user's browser will likely refuse to load the images, css, JS via `http` if the original page was requested via `https`.  

This PR just checks for the presence of an `X-Forwarded-Proto` header and uses it if available.  This fixes the problem on Heroku, at least. 