### PR TITLE
Fix issue with None in notes and summary if there is no doc for method

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -312,7 +312,7 @@ class SwaggerEndpoint(object):
               op['parameters'] = merge_parameter_list(
                 op['parameters'], att_value)
             else:
-              if att_name in op and att_name is not 'nickname':
+              if op.get(att_name) and att_name is not 'nickname':
                 att_value = '{0}<br/>{1}'.format(att_value, op[att_name])
               op[att_name] = att_value
           elif isinstance(att_value, object):


### PR DESCRIPTION
Hi,

this is another proposition for resolving issue #59 .

Now, it works fine when you define notes/summary in decorator and have no empty operation comment.

Cheers