### PR TITLE
Create custom auth headers in swagger-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,10 @@ apiVersion - passed directly to swagger as the apiVersion attribute. Default: 0.
 
 basePath - passed directly to swagger as the basePath attribute. Default: 'http://localhost:5000' (do not include a slash at the end)
 
-authTokenType - by default, swagger-ui allows a user to input an api key, which will format all outgoing requests with a query string parameter (i.e., `?api_key=<your secret token>`). By passing a a string such as 'Client' or 'Bearer', swagger-ui will add an auth header in the following format: `Authorization: Client <your secret token>`
+authTokenType - by default, swagger-ui allows a user to input an api key, which will format all
+outgoing requests with a query string parameter (i.e., ?api_key=<your secret token>). By passing a
+string such as 'Client' or 'Bearer', swagger-ui will add an auth header in the following format:
+Authorization: Client <your secret token>
 
 resourcePath - same as before. default: '/'
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ class Todo(Resource):
           ]
         )
     def get(self, todo_id):
-    
+
 # Operations not decorated with @swagger.operation do not get added to the swagger docs
 
 class Todo(Resource):
@@ -199,6 +199,8 @@ apiVersion - passed directly to swagger as the apiVersion attribute. Default: 0.
 
 basePath - passed directly to swagger as the basePath attribute. Default: 'http://localhost:5000' (do not include a slash at the end)
 
+authTokenType - by default, swagger-ui allows a user to input an api key, which will format all outgoing requests with a query string parameter (i.e., `?api_key=<your secret token>`). By passing a a string such as 'Client' or 'Bearer', swagger-ui will add an auth header in the following format: `Authorization: Client <your secret token>`
+
 resourcePath - same as before. default: '/'
 
 produces - same as before, passed directly to swagger. The default is ["application/json"]
@@ -210,9 +212,9 @@ description - description of this API endpoint. Defaults to 'Auto generated API 
 
 # Accessing the result json spec and an Interactive HTML interface
 Assuming you provided `swagger.docs` with a parameter `api_spec_url='/api/spec'` (or left out in which case the default is '/api/spec') you may access the resulting json at /api/spec.json.
-You may also access /api/spec.html where you'd find an interactive HTML page that lets you play with the API to some extent.  
+You may also access /api/spec.html where you'd find an interactive HTML page that lets you play with the API to some extent.
 
-Here's how this HTML page would look like: 
+Here's how this HTML page would look like:
 
 ![An example /api/spec.html page](http://cl.ly/image/312Q2u091u24/Screen%20Shot%202013-12-17%20at%2012.26.02%20PM.png)
 

--- a/flask_restful_swagger/static/index.html
+++ b/flask_restful_swagger/static/index.html
@@ -54,8 +54,13 @@
       if(key && key.trim() != "") {
         log("added key " + key);
         window.authorizations.add("key", new ApiKeyAuthorization("api_key", key, "query"));
+
+        {% if '{{auth_token_type}}' %}
+          window.authorizations.add('key', new ApiKeyAuthorization('Authorization', '{{auth_token_type}} ' + key, 'header'));
+        {% endif %}
       }
     })
+
     window.swaggerUi.load();
   });
   </script>

--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -21,6 +21,7 @@ resource_listing_endpoint = None
 
 def docs(api, apiVersion='0.0', swaggerVersion='1.2',
          basePath='http://localhost:5000',
+         authTokenType=None,
          resourcePath='/',
          produces=["application/json"],
          api_spec_url='/api/spec',
@@ -30,7 +31,7 @@ def docs(api, apiVersion='0.0', swaggerVersion='1.2',
 
   def add_resource(resource, *urls, **kvargs):
     register_once(api, api_add_resource, apiVersion, swaggerVersion, basePath,
-                  resourcePath, produces, api_spec_url, description)
+                  resourcePath, produces, api_spec_url, description, authTokenType)
 
     resource = make_class(resource)
     for url in urls:
@@ -63,7 +64,7 @@ def make_class(class_or_instance):
 
 
 def register_once(api, add_resource_func, apiVersion, swaggerVersion, basePath,
-                  resourcePath, produces, endpoint_path, description):
+                  resourcePath, produces, endpoint_path, description, authTokenType):
   global api_spec_static
   global resource_listing_endpoint
 
@@ -73,6 +74,7 @@ def register_once(api, add_resource_func, apiVersion, swaggerVersion, basePath,
       'apiVersion': apiVersion,
       'swaggerVersion': swaggerVersion,
       'basePath': basePath,
+      'authTokenType': authTokenType,
       'spec_endpoint_path': endpoint_path,
       'resourcePath': resourcePath,
       'produces': produces,
@@ -108,6 +110,7 @@ def register_once(api, add_resource_func, apiVersion, swaggerVersion, basePath,
       'apiVersion': apiVersion,
       'swaggerVersion': swaggerVersion,
       'basePath': basePath,
+      'authTokenType': authTokenType,
       'spec_endpoint_path': endpoint_path,
       'resourcePath': resourcePath,
       'produces': produces,
@@ -148,7 +151,6 @@ def render_homepage(resource_list_url):
 
 
 def _get_current_registry(api=None):
-  # import ipdb;ipdb.set_trace()
   global registry
   app_name = None
   overrides = {}
@@ -180,7 +182,8 @@ def render_page(page, info):
     url = url.rstrip('/')
   conf = {
     'base_url': url + api_spec_static,
-    'full_base_url': url + api_spec_static
+    'full_base_url': url + api_spec_static,
+    'auth_token_type': req_registry['authTokenType']
   }
   if info is not None:
     conf.update(info)


### PR DESCRIPTION
Please see the question I raised here: https://github.com/rantav/flask-restful-swagger/issues/100

This PR allows users to pass an optional kwarg that enables Authorization headers to be passed when given an API key
