### PR TITLE
Fix Deprecation Warnings

### DIFF
--- a/flask_restful_swagger/swagger.py
+++ b/flask_restful_swagger/swagger.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 from flask import request, abort, Response
-from flask.ext.restful import Resource, fields
+from flask_restful import Resource, fields
 from flask_restful_swagger import (
   registry, api_spec_static)
 from jinja2 import Template


### PR DESCRIPTION
Flask Version: 0.11.1

```
/Users/soltysik/.envs/secret-app/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.restful is deprecated, use flask_restful instead. .format(x=modname), ExtDeprecationWarning
/Users/soltysik/.envs/secret-app/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.restful.fields is deprecated, use flask_restful.fields instead. .format(x=modname), ExtDeprecationWarning
```