### PR TITLE
Pipeline - fix py2 old-style classes causing test issues in add_model

### DIFF
--- a/tests/fixtures_add_model.py
+++ b/tests/fixtures_add_model.py
@@ -75,10 +75,14 @@ def patch_getargspec():
 
 
 class MockBasicObject:
-    pass
+    def __init__(self, arg1):
+        pass
 
 
 class MockBasicWithSwaggerMetadata1:
+    def __init__(self, arg1):
+        pass
+
     swagger_metadata = {"an_enum": {"enum": ["one", "two", "three"]}}
 
 

--- a/tests/test_add_model.py
+++ b/tests/test_add_model.py
@@ -62,10 +62,20 @@ def test_integration_test_add_model(test_input, properties, required, defaults):
         assert "description" in registry["models"][test_input.__name__]
         assert "notes" in registry["models"][test_input.__name__]
 
+        if "resource_fields" not in dir(test_input) and "__init__" not in dir(
+            test_input
+        ):
+            # in py2, classes without __init__ or resource_fields defined
+            # will cause issues.
+            # note, no issue in PY3.
+            pytest.fail(
+                "do not call without resource_fields or __init__ defined."
+            )
+
         if "resource_fields" in dir(test_input):
             if hasattr(test_input, "required"):
                 assert "required" in registry["models"][test_input.__name__]
-        else:
+        elif "__init__" in dir(test_input):
             assert "required" in registry["models"][test_input.__name__]
 
         assert "properties" in registry["models"][test_input.__name__]


### PR DESCRIPTION
Investigated the cause of the testing issues in PY2 are related to old-style classes.  To safe-guard against the errors,  always use new-style classes in test fixtures  (explicitly inherit from `object`).